### PR TITLE
Add quartus-dev target invoking Quartus container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+# Top-level Makefile for myMisterTemplate
+#
+# Provides convenience targets for working with the Quartus container
+# wrapper that lives in scripts/quartus.
+
+PROJECT ?= mycore
+QUARTUS_DEV_CMD ?= quartus_sh --flow compile $(PROJECT)
+
+.PHONY: quartus-dev
+quartus-dev:
+	./scripts/quartus $(QUARTUS_DEV_CMD)
+


### PR DESCRIPTION
## Summary
- add a top-level Makefile so developers can run Quartus via the project wrapper
- provide a `quartus-dev` target that defaults to compiling the `mycore` project but supports overrides

## Testing
- make -n quartus-dev


------
https://chatgpt.com/codex/tasks/task_e_68d45d26603c8326a818788d9b95dd65